### PR TITLE
Update supported PHP Versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.4|^8.0",
         "statamic/cms": "^3.0.23",
         "league/commonmark": "^1.3.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.3|^8.0",
         "statamic/cms": "^3.0.23",
         "league/commonmark": "^1.3.3"
     },


### PR DESCRIPTION
https://www.php.net/supported-versions

I tried to install this into a local project, and couldn't due to PHP version constraints.

So this now supports PHP8 and all the tests passed in my 8.0.5 environment.

I've also increased the minimum version to PHP 7.3 