### PR TITLE
Feature updates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 include:
                     - laravel: 8.*
-                      testbench: 6.*
+                      testbench: 6.17.*
                     - laravel: 7.*
                       testbench: 5.*
                 exclude:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,15 @@ jobs:
                 os: [ubuntu-latest]
                 include:
                     - laravel: 8.*
-                      testbench: 6.17.*
+                      testbench: 6.*
                     - laravel: 7.*
                       testbench: 5.*
+                    - php: 8.0
+                      laravel: 7.*
+                      statamic: 3.0.23
+                      dependency-version: prefer-lowest
+                      testbench: 5.*
+                      additional-deps: "mockery/mockery:>=1.3.3"
                 exclude:
                   - php: 8.0
                     statamic: 3.0.23
@@ -47,7 +53,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "statamic/cms:${{ matrix.statamic }}" --no-interaction --no-update
+                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "statamic/cms:${{ matrix.statamic }}" ${{ matrix.additional-deps }} --no-interaction --no-update
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,11 +23,8 @@ jobs:
                     - laravel: 7.*
                       testbench: 5.*
                     - php: 8.0
-                      laravel: 7.*
-                      statamic: 3.1.*
                       dependency-version: prefer-lowest
-                      testbench: 5.*
-                      additional-deps: "mockery/mockery:>=1.3.3"
+                      additional-deps: "mockery/mockery:^1.3.3"
                 exclude:
                   - php: 8.0
                     statamic: 3.0.23

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
                       testbench: 5.*
                     - php: 8.0
                       laravel: 7.*
-                      statamic: 3.0.23
+                      statamic: 3.1.*
                       dependency-version: prefer-lowest
                       testbench: 5.*
                       additional-deps: "mockery/mockery:>=1.3.3"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
                       testbench: 5.*
                 exclude:
                   - php: 8.0
-                    statmic: 3.0.23
+                    statamic: 3.0.23
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - S${{ matrix.statamic }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,7 @@ jobs:
             matrix:
                 php: [8.0, 7.4, 7.3]
                 laravel: [8.*, 7.*]
+                statamic: [3.0.23, 3.1.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
@@ -21,8 +22,11 @@ jobs:
                       testbench: 6.*
                     - laravel: 7.*
                       testbench: 5.*
+                exclude:
+                  - php: 8.0
+                    statmic: 3.0.23
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - S${{ matrix.statamic }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
@@ -32,7 +36,7 @@ jobs:
               uses: actions/cache@v1
               with:
                   path: ~/.composer/cache/files
-                  key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+                  key: dependencies-laravel-${{ matrix.laravel }}-statamic-${{ matrix.statamic }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -43,7 +47,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "statamic/cms:${{ matrix.statamic }}" --no-interaction --no-update
+                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/Tests/Unit/GenerateTocExtensionTest.php
+++ b/Tests/Unit/GenerateTocExtensionTest.php
@@ -125,4 +125,18 @@ class GenerateTocExtensionTest extends TestCase
         $this->assertStringContainsString("<li class=\"child\">\n<p>Fifth Heading</p>\n</li>", $result);
         $this->assertStringContainsString("<li class=\"child\">\n<p>Seventh Heading</p>\n</li>", $result);
     }
+
+    /** @test */
+    public function it_does_not_add_extension_if_there_are_no_headings()
+    {
+        $content = <<<EOL
+        Paragraph for testing
+        
+        And a second paragraph
+        EOL;
+
+        $result = Markdown::parse($content);
+
+        $this->assertStringNotContainsString('<ul', $result);
+    }
 }

--- a/Tests/Unit/GenerateTocExtensionTest.php
+++ b/Tests/Unit/GenerateTocExtensionTest.php
@@ -127,7 +127,7 @@ class GenerateTocExtensionTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_add_extension_if_there_are_no_headings()
+    public function it_does_not_add_extension_if_there_are_no_headings_in_content()
     {
         $content = <<<EOL
         Paragraph for testing

--- a/Tests/Unit/GenerateTocExtensionTest.php
+++ b/Tests/Unit/GenerateTocExtensionTest.php
@@ -123,7 +123,7 @@ class GenerateTocExtensionTest extends TestCase
         $result = Markdown::parse($this->content);
         $this->assertStringContainsString("<li class=\"child\">\n<p>Fourth Heading</p>\n</li>", $result);
         $this->assertStringContainsString("<li class=\"child\">\n<p>Fifth Heading</p>\n</li>", $result);
-        $this->assertStringContainsString("<li class=\"child\">\n<p>Seventh Heading</p>\n</li>", $result);
+        $this->assertStringContainsString("<li class=\"child grandchild\">\n<p>Seventh Heading</p>\n</li>", $result);
     }
 
     /** @test */

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "statamic/cms": "^3.0.23 | ^ 3.1",
+        "statamic/cms": "^3.0.23 | ^3.1",
         "league/commonmark": "^1.3.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "league/commonmark": "^1.3.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0",
-        "phpunit/phpunit": "^8.5"
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.5"
     },
  	"autoload-dev": {
     	"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.4|^8.0",
         "statamic/cms": "^3.0.23",
         "league/commonmark": "^1.3.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,8 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "statamic/cms": "3.1.*",
-        "league/commonmark": "^1.3.3",
-        "laravel/framework": "7.*",
-        "orchestra/testbench": "5.*",
-        "mockery/mockery": "1.3.3"
+        "statamic/cms": "^3.0.23 | ^ 3.1",
+        "league/commonmark": "^1.3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 | ^9.5"

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "statamic/cms": "^3.0.23",
+        "statamic/cms": "^3.0.23 | ^3.1.0",
         "league/commonmark": "^1.3.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.5"
+        "orchestra/testbench": "^v5.0 | ^v6.0",
+        "phpunit/phpunit": "^8.5 | ^9.5"
     },
  	"autoload-dev": {
     	"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.3|^8.0",
         "statamic/cms": "^3.0.23",
         "league/commonmark": "^1.3.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,13 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "statamic/cms": "^3.0.23 | ^3.1.0",
-        "league/commonmark": "^1.3.3"
+        "statamic/cms": "3.1.*",
+        "league/commonmark": "^1.3.3",
+        "laravel/framework": "7.*",
+        "orchestra/testbench": "5.*",
+        "mockery/mockery": "1.3.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^v5.0 | ^v6.0",
         "phpunit/phpunit": "^8.5 | ^9.5"
     },
  	"autoload-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,10 +7,7 @@
   </coverage>
   <testsuites>
     <testsuite name="Unit">
-      <directory suffix="Test.php">tests/Unit/</directory>
-    </testsuite>
-    <testsuite name="Feature">
-      <directory suffix="Test.php">tests/Feature/</directory>
+      <directory>Tests/Unit/</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/src/Extensions/CommonMark/TitleAnchorIdProcessor.php
+++ b/src/Extensions/CommonMark/TitleAnchorIdProcessor.php
@@ -8,7 +8,8 @@ use League\CommonMark\Event\DocumentParsedEvent;
 
 final class TitleAnchorIdProcessor
 {
-    private EnvironmentInterface $environment;
+    /** @var EnvironmentInterface  */
+    private $environment;
 
     public function __construct(EnvironmentInterface $environment)
     {

--- a/src/Extensions/CommonMark/TitleAnchorIdProcessor.php
+++ b/src/Extensions/CommonMark/TitleAnchorIdProcessor.php
@@ -8,14 +8,6 @@ use League\CommonMark\Event\DocumentParsedEvent;
 
 final class TitleAnchorIdProcessor
 {
-    /** @var EnvironmentInterface  */
-    private $environment;
-
-    public function __construct(EnvironmentInterface $environment)
-    {
-        $this->environment = $environment;
-    }
-
     public function __invoke(DocumentParsedEvent $e)
     {
         $walker = $e->getDocument()->walker();

--- a/src/Extensions/CommonMark/TitleAnchorIdProcessor.php
+++ b/src/Extensions/CommonMark/TitleAnchorIdProcessor.php
@@ -3,7 +3,6 @@
 namespace Njed\Toc\Extensions\CommonMark;
 
 use League\CommonMark\Block\Element\Heading;
-use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 
 final class TitleAnchorIdProcessor

--- a/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
+++ b/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
@@ -7,7 +7,6 @@ use League\CommonMark\Block\Element\ListBlock;
 use League\CommonMark\Block\Element\ListData;
 use League\CommonMark\Block\Element\ListItem;
 use League\CommonMark\Block\Element\Paragraph;
-use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Element\Text;
@@ -20,7 +19,7 @@ final class TransformHeadingsToListOfLinksProcessor
 
         $data = new ListData;
         $data->markerOffset = 0;
-        $data->type = ListBlock::TYPE_UNORDERED;
+        $data->type = ListBlock::TYPE_BULLET;
 
         $listBlock = new ListBlock($data);
         $listBlock->data['attributes']['class'] = 'table-of-contents';

--- a/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
+++ b/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
@@ -14,7 +14,8 @@ use League\CommonMark\Inline\Element\Text;
 
 final class TransformHeadingsToListOfLinksProcessor
 {
-    private EnvironmentInterface $environment;
+    /** @var EnvironmentInterface  */
+    private $environment;
 
     public function __construct(EnvironmentInterface $environment)
     {

--- a/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
+++ b/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
@@ -63,7 +63,10 @@ final class TransformHeadingsToListOfLinksProcessor
         }
 
         $e->getDocument()->detachChildren();
-        $e->getDocument()->appendChild($listBlock);
+        // Only if there are items should we add the TOC
+        if (!empty($listBlock->children())) {
+            $e->getDocument()->appendChild($listBlock);
+        }
     }
 
     private function configIncludesLevel(string $level): bool

--- a/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
+++ b/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
@@ -76,14 +76,13 @@ final class TransformHeadingsToListOfLinksProcessor
     private function getNodeClasses($nodeLevel): string
     {
         $classes = [];
+        // h3 headings
         if ($nodeLevel > 2) {
             $classes[] = 'child';
         }
+        // h4 headings
         if ($nodeLevel > 3) {
             $classes[] = 'grandchild';
-        }
-        if ($nodeLevel > 4) {
-            $classes[] = 'grandgrandchild';
         }
         return implode(' ', $classes);
     }

--- a/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
+++ b/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
@@ -14,14 +14,6 @@ use League\CommonMark\Inline\Element\Text;
 
 final class TransformHeadingsToListOfLinksProcessor
 {
-    /** @var EnvironmentInterface  */
-    private $environment;
-
-    public function __construct(EnvironmentInterface $environment)
-    {
-        $this->environment = $environment;
-    }
-
     public function __invoke(DocumentParsedEvent $e)
     {
         $walker = $e->getDocument()->walker();

--- a/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
+++ b/src/Extensions/CommonMark/TransformHeadingsToListOfLinksProcessor.php
@@ -45,10 +45,7 @@ final class TransformHeadingsToListOfLinksProcessor
                     $listItem->appendChild($paragraph);
                 }
 
-
-                if ($node->getLevel() > 2) {
-                    $listItem->data['attributes']['class'] = 'child';
-                }
+                $listItem->data['attributes']['class'] = $this->getNodeClasses($node->getLevel());
 
                 $listBlock->appendChild($listItem);
             }
@@ -68,5 +65,26 @@ final class TransformHeadingsToListOfLinksProcessor
         }
 
         return collect(config('toc.includeLevels'))->contains($level);
+    }
+
+    /**
+     * Returns the classes for a list element based on it's depth
+     *
+     * @param $nodeLevel
+     * @return string
+     */
+    private function getNodeClasses($nodeLevel): string
+    {
+        $classes = [];
+        if ($nodeLevel > 2) {
+            $classes[] = 'child';
+        }
+        if ($nodeLevel > 3) {
+            $classes[] = 'grandchild';
+        }
+        if ($nodeLevel > 4) {
+            $classes[] = 'grandgrandchild';
+        }
+        return implode(' ', $classes);
     }
 }

--- a/src/Listeners/GenerateToc.php
+++ b/src/Listeners/GenerateToc.php
@@ -21,7 +21,7 @@ class GenerateToc
 
             Markdown::extend('default', function ($parser) {
                 return $parser
-                    ->addExtension(fn() => new GenerateTocExtension);
+                    ->addExtension(function () { return new GenerateTocExtension; });
             });
 
             $headings = Markdown::parse($content);


### PR DESCRIPTION
1. Don't output a TOC if there are no headings in a markdown file
2. Add a `grandchild` class to the output to allow better targeting via css
3. Gets the tests to run in a case sensitive environment (i.e. linux)
4. Update phpunit and benchmark to latest versions
5. Replaces a deprecated value in `CommonMark`

I have a `docker-compose` file that I tested with locally, which I have not included with this PR. I can easily do that if you'd like?

Also, since this would technically be a 1.1 release feel free to reject this if it is too large. I'd just need to fork this and use it locally if that is the case.

I've tried to use a TDD approach so you can follow along in the commits (if you're interested) to see what changed and why.